### PR TITLE
update with kubernetes operator for disk mgmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Projects and products:
   - [Operator SDK](https://github.com/operator-framework/operator-sdk)
   - [Awesome Operators in the Wild](https://github.com/operator-framework/awesome-operators)
   - [Kanister - An Operator Focused on App-Level Data Management](https://github.com/kanisterio/kanister)
+  - [Node Disk Manager for Kubernetes](https://github.com/openebs/node-disk-manager)
 
 ## Backup and restore
 


### PR DESCRIPTION
NDM is a Kubernetes Operator for discovering and managing block devices attached to the Kubernetes nodes. It can be used by other tools for provisioning Local PVs or assigning block devices to storages like OpenEBS, GlusterFs etc., 