### PR TITLE
Suggesting a new category called Chaos Engineering Frameworks for Stateful applications

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,4 @@
 Michael Hausenblas, https://mhausenblas.info
 Goutham Kolluru
 Niraj Tolia, @nirajtolia
+Umasankar Mukkara, @umamukkara

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Projects and products:
   - [Rook](http://rook.io/)
   - [StorageOS](http://storageos.com)
   - [Stork](https://github.com/libopenstorage/stork)
- - Chaos Engineering frameworks
-   - [Litmus] (https://github.com/openebs/litmus)
+- Chaos Engineering frameworks
+  - [Litmus](https://github.com/openebs/litmus)
 
 ## Datastores and operators
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Projects and products:
   - [StorageOS](http://storageos.com)
   - [Stork](https://github.com/libopenstorage/stork)
  - Chaos Engineering frameworks
-  - [Litmus] (https://github.com/openebs/litmus)
+   - [Litmus] (https://github.com/openebs/litmus)
 
 ## Datastores and operators
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Projects and products:
   - [Rook](http://rook.io/)
   - [StorageOS](http://storageos.com)
   - [Stork](https://github.com/libopenstorage/stork)
+ - Chaos Engineering frameworks
+  - [Litmus] (https://github.com/openebs/litmus)
 
 ## Datastores and operators
 


### PR DESCRIPTION
Agile testing and practicing chaos engineering in DevOps are key areas in the lifecycle of stateful applications. I am suggesting a sub section or category to your awesome list and added Litmus as one of the frameworks there. 