### PR TITLE
Added NetApp Trident to projects and products

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Projects and products:
   - [Rook](http://rook.io/)
   - [StorageOS](http://storageos.com)
   - [Stork](https://github.com/libopenstorage/stork)
+  - [NetApp Trident](https://github.com/NetApp/trident)
 - Chaos Engineering frameworks
   - [Litmus](https://github.com/openebs/litmus)
 


### PR DESCRIPTION
Note: please add yourself to the [CONTRIBUTORS](https://github.com/mhausenblas/stateful-kubernetes/blob/master/CONTRIBUTORS) file.
