### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Official Kubernetes docs and specifications.
   - [StorageOS](http://storageos.com)
   - [Stork](https://github.com/libopenstorage/stork)
   - [NetApp Trident](https://github.com/NetApp/trident)
+  - [Elastifile](https://www.elastifile.com/)
 - Chaos Engineering frameworks
   - [Litmus](https://github.com/openebs/litmus)
 


### PR DESCRIPTION
Add Elastifile as Enterprise-Grade scalable file storage for the public cloud

Note: please add yourself to the [CONTRIBUTORS](https://github.com/mhausenblas/stateful-kubernetes/blob/master/CONTRIBUTORS) file.
